### PR TITLE
Fixed buffer class to be more portable and correct

### DIFF
--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -1,10 +1,10 @@
 #include "Buffer.h"
 
 template<class T>
-Buffer<T>::Buffer(std::string identifer, unsigned short initSize){
+Buffer<T>::Buffer(std::string identifer,
+		typename std::deque<T>::size_type initSize){
 	this->identifier = identifier;
-	size = initSize;
-
+	data.resize(initSize);
 }
 
 template<class T>
@@ -19,12 +19,10 @@ void Buffer<T>::setIdentifier(std::string identifier){
 
 template<class T>
 void Buffer<T>::push(T newData){
-	if(size = 0){return;}
+	if(this->getMaxSize == 0){return;}
 
-	while(data.getSize() = size){
-		this->pop();
-	}
-	data.push(newData);
+	this->data.pop_front();  // Should remove enough
+	this->data.push_back(newData);
 }
 
 template<class T>
@@ -32,7 +30,7 @@ T Buffer<T>::pop(){
 	if(!data.empty()){
 		T buff;
 		buff = data.front();
-		data.pop_back();
+		data.pop_front();
 		return buff;
 	}
 }
@@ -45,11 +43,16 @@ T Buffer<T>::get(){
 }
 
 template<class T>
-void Buffer<T>::resize(unsigned short newSize){
+void Buffer<T>::resize(typename std::deque<T>::size_type newSize){
 	data.resize(newSize);
 }
 
 template<class T>
-unsigned short Buffer<T>::getSize(){
-	return size;
+auto Buffer<T>::getMaxSize(){
+	return data.max_size();
+}
+
+template<class T>
+auto Buffer<T>::getSize(){
+	return data.size();
 }

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -1,13 +1,13 @@
 #ifndef __INTERCHANGE_BUFFER_H
 #define __INTERCHANGE_BUFFER_H
 
-#include <queue>
+#include <deque>
 #include <string>
 
 template<class T>
 class Buffer{
 public:
-	Buffer(std::string identifier, unsigned short initSize);
+	Buffer(std::string identifier, typename std::deque<T>::size_type initSize);
 
 	std::string getIdentifier();
 	void setIdentifier(std::string identifier);
@@ -16,13 +16,13 @@ public:
 	T pop();
 	T get();
 
-	void resize(unsigned short newSize);
-	unsigned short getSize();
+	void resize(typename std::deque<T>::size_type newSize);
+	auto getSize();
+	auto getMaxSize();
 
 private:
 	std::string identifier;
 	std::deque<T> data;
-	unsigned short size;
 };
 
 #endif //__INTERCHANGE_BUFFER_H


### PR DESCRIPTION
-Changed unsigned short to std::queue<T>::size_type for portability
-Fixed = to == in comparisons
-Added maxsize getter
-Fixed size getter
-Changed standard from C++11 to C++14 for use of auto rather than the long type names in functions
-Did not make exceptions.
